### PR TITLE
Mention that channel should be a string and correct permission docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Simple action which sends a message over to discord news channel and crossposts 
 
 ## Inputs
 
-| Input name | Description                                                                                                                        | Required | Default Value |
-|------------|------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| bot-token  | Discord bot token. This bot should have `SEND_MESSAGES` and `MANAGE_MESSAGES` permissions in the news channel you want to post in. | `true`   | `N/A`         |
-| channel    | A string being the channel id of the news channel you want to post the message in. Channel **MUST** be a news channel.             | `true`   | `N/A`         |
-| content    | The message content which should be sent.                                                                                          | `true`   | `N/A`         |
+| Input name | Description                                                                                                            | Required | Default Value |
+|------------|------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| bot-token  | Discord bot token. This bot should have the `SEND_MESSAGES` permission in the news channel you want to post in.        | `true`   | `N/A`         |
+| channel    | A string being the channel id of the news channel you want to post the message in. Channel **MUST** be a news channel. | `true`   | `N/A`         |
+| content    | The message content which should be sent.                                                                              | `true`   | `N/A`         |
 
 ## Example Job
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple action which sends a message over to discord news channel and crossposts 
 | Input name | Description                                                                                                                        | Required | Default Value |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
 | bot-token  | Discord bot token. This bot should have `SEND_MESSAGES` and `MANAGE_MESSAGES` permissions in the news channel you want to post in. | `true`   | `N/A`         |
-| channel    | The channel id of the news channel you want to post the message in. Channel **MUST** be a news channel.                            | `true`   | `N/A`         |
+| channel    | A string being the channel id of the news channel you want to post the message in. Channel **MUST** be a news channel.             | `true`   | `N/A`         |
 | content    | The message content which should be sent.                                                                                          | `true`   | `N/A`         |
 
 ## Example Job
@@ -20,7 +20,7 @@ Simple action which sends a message over to discord news channel and crossposts 
         uses: Crec0/announce-n-crosspost@v1
         with:
           bot-token: ${{ secrets.DISCORD_BOT_TOKEN }}
-          channel: $CHANNEL_ID
+          channel: '$CHANNEL_ID'
           content: |
             **${{ github.event.release.name }}** has been released!
             

--- a/src/announce.js
+++ b/src/announce.js
@@ -81,8 +81,7 @@ async function sendAndPublishMessage(axiosInstance, channel, content) {
     if (crosspostResponse.status !== SUCCESS) {
         throw new Error(
             `(${response.status}) Failed to crosspost message in ${channelName} in ${guildName}. ` +
-            `Error: ${response.statusText}. ` +
-            `Please check if the bot has MANAGE_MESSAGES permission.`
+            `Error: ${response.statusText}. `
         );
     }
     core.debug("Message published in news channel");


### PR DESCRIPTION
Bot only needs `SEND_MESSAGES` permission if it's the author of the message, and it is.

![imagen](https://user-images.githubusercontent.com/17107132/164971610-ae48b114-92e0-4df1-a796-f16c2711cebd.png)
