### PR TITLE
Add message id output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   content:
     description: 'The content of the message to send'
     required: true
+outputs:
+  message-id:
+    description: 'The id of the sent message'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/announce.js
+++ b/src/announce.js
@@ -75,6 +75,7 @@ async function sendAndPublishMessage(axiosInstance, channel, content) {
 
     const responseJson = response.data;
     const messageId = responseJson.id;
+    core.setOutput("message-id", messageId);
 
     const crosspostRequest = prepareRoute(CROSSPOST_MESSAGE, { channel: channel,  message: messageId});
     const crosspostResponse = await axiosInstance.post(crosspostRequest, {data: responseJson});


### PR DESCRIPTION
This PR makes the action output the id of the sent message as an output.

And it seems also adds newlines at the end of the files, because github web editor likes to do that (and tbh there's no reason they shouldn't be there).

Draft because it's not tested at all. Though idk if/when I'm going to test it, given I don't have anything to use it for.

Science isn't about why, it's about _why not_ :tiny_potato:.