### PR TITLE
Remove notice issue from output

### DIFF
--- a/src/announce.js
+++ b/src/announce.js
@@ -86,7 +86,6 @@ async function sendAndPublishMessage(axiosInstance, channel, content) {
         );
     }
     core.info(`Message crossposted in ${channelName} in ${guildName}`);
-    core.notice(`Message successfully send and crossposted in ${channelName} in ${guildName}`);
 }
 
 async function announce() {


### PR DESCRIPTION
Log should be good enough, and if it wasn't crossposted successfully it should fail instead.

Else you get this:

![imagen](https://user-images.githubusercontent.com/17107132/166153846-f5eeca07-2a7f-416a-a94b-c9597f4e4920.png)
